### PR TITLE
adjust(wordpress):meta values are stored, custom post created, creati…

### DIFF
--- a/wordpress/wp-content/themes/ws-custom-theme/archive-post.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/archive-post.php
@@ -1,0 +1,13 @@
+<?php get_header(); ?>
+<div class="container">
+    <?php
+        if ( have_posts() ) :
+            while( have_posts() ) : the_post() ;
+                the_title();
+                the_content();
+            endwhile;
+        endif;
+        
+    ?>
+</div>
+<?php get_footer(); ?>

--- a/wordpress/wp-content/themes/ws-custom-theme/front-page.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/front-page.php
@@ -1,1 +1,0 @@
-This is the front page

--- a/wordpress/wp-content/themes/ws-custom-theme/functions.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/functions.php
@@ -1,26 +1,22 @@
 <?php
     add_action('wp_head', 'hook_javascript');
 
-    add_filter( 'the_content', 'change_content' );
-
     function hook_javascript() {
-        echo "Hello world...";
+        echo "Hello world...<br>";
         echo "This is an action hook";
     }
 
-    function change_content ( $content ) {
-        $content = 'This is a filter hooks';
-        return $content;
-    }
+    $addMetaValues=apply_filters('writeMeta',1,'meta_description','post meta value');
 
-    add_filter('writeMeta','storeMetaPost',10,4);
-    function storeMetaPost( $post_id, $meta_key, $meta_value, $unique = false ) {
+    add_filter('writeMeta','storeMetaPost',10,3);
+
+    function storeMetaPost( $post_id, $meta_key, $meta_value) {
         $the_post = wp_is_post_revision( $post_id );
         if ( $the_post ) {
             $post_id = $the_post;
         }
     
-        return add_metadata( 'post', $post_id, $meta_key, $meta_value, $unique );
+        return add_post_meta( 'post', $post_id, $meta_key, $meta_value);
     }
 
     add_action( 'init', 'register_news_cpt' );
@@ -32,8 +28,9 @@
                                             'singular_name' => __( 'News' ),
                                             'description' => __('Independent sources'),
                                         ),
+                                        "description" => "All the news content will be posted with this type of post",
                                         'public' => true,
-                                        'has_archive' => false,
+                                        'has_archive' => true,
                                         'rewrite' => array('slug' => 'news'),
                                     )
                             );

--- a/wordpress/wp-content/themes/ws-custom-theme/functions.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/functions.php
@@ -1,10 +1,41 @@
 <?php
-    function hook_javascript() {
-        ?>
-            <script>
-                alert('Hello world...');
-            </script>
-        <?php
-    }
     add_action('wp_head', 'hook_javascript');
+
+    add_filter( 'the_content', 'change_content' );
+
+    function hook_javascript() {
+        echo "Hello world...";
+        echo "This is an action hook";
+    }
+
+    function change_content ( $content ) {
+        $content = 'This is a filter hooks';
+        return $content;
+    }
+
+    add_filter('writeMeta','storeMetaPost',10,4);
+    function storeMetaPost( $post_id, $meta_key, $meta_value, $unique = false ) {
+        $the_post = wp_is_post_revision( $post_id );
+        if ( $the_post ) {
+            $post_id = $the_post;
+        }
+    
+        return add_metadata( 'post', $post_id, $meta_key, $meta_value, $unique );
+    }
+
+    add_action( 'init', 'register_news_cpt' );
+    function register_news_cpt() {
+        register_post_type( 'news',array(
+                                    'labels' => 
+                                        array(
+                                            'name' => __( 'News' ),
+                                            'singular_name' => __( 'News' ),
+                                            'description' => __('Independent sources'),
+                                        ),
+                                        'public' => true,
+                                        'has_archive' => false,
+                                        'rewrite' => array('slug' => 'news'),
+                                    )
+                            );
+        }
 ?>

--- a/wordpress/wp-content/themes/ws-custom-theme/index.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/index.php
@@ -1,1 +1,6 @@
 <h1>hello world!</h1>
+<?php
+    wp_head();
+    the_content();
+    $addMetaValues=apply_filters('writeMeta',1,'meta_description','post meta value',false);
+?>

--- a/wordpress/wp-content/themes/ws-custom-theme/index.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/index.php
@@ -1,6 +1,4 @@
-<h1>hello world!</h1>
 <?php
-    wp_head();
-    the_content();
-    $addMetaValues=apply_filters('writeMeta',1,'meta_description','post meta value',false);
+    get_header();
+    get_footer();
 ?>


### PR DESCRIPTION
…ng archive page

set the meta values for post in the postmeta table
1. add_meta_data->adds met data for the specified object
2. register_post_type->Registers a post type with specified post type
3. have_posts->Determines whether current WordPress query has posts to loop over.
Created a custom post in the dashboard named News
Creating archive page for the custom post
![Screenshot (34)](https://github.com/DaraniShri/wordpress/assets/137259204/4f790c00-f4dc-4492-8f0b-16e6943ca9f4)
![Screenshot (33)](https://github.com/DaraniShri/wordpress/assets/137259204/781104d4-a9e3-4614-9f63-f5faec8914fa)
![Screenshot (32)](https://github.com/DaraniShri/wordpress/assets/137259204/47e147b7-365d-4b55-ba2d-aa74800c7476)
