### PR TITLE
adjust(wordpress):filter call is changed in functions.php

### DIFF
--- a/wordpress/wp-content/themes/ws-custom-theme/front-page.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/front-page.php
@@ -1,1 +1,0 @@
-This is the front page

--- a/wordpress/wp-content/themes/ws-custom-theme/functions.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/functions.php
@@ -1,10 +1,44 @@
 <?php
-    function hook_javascript() {
-        ?>
-            <script>
-                alert('Hello world...');
-            </script>
-        <?php
-    }
     add_action('wp_head', 'hook_javascript');
+
+    add_filter( 'the_content', 'change_content' );
+
+    function hook_javascript() {
+        echo "Hello world...";
+        echo "This is an action hook";
+    }
+
+    function change_content ( $content ) {
+        $content = 'This is a filter hooks';
+        return $content;
+    }
+
+    $addMetaValues=apply_filters('writeMeta',1,'meta_description','post meta value');
+
+    add_filter('writeMeta','storeMetaPost',10,3);
+
+    function storeMetaPost( $post_id, $meta_key, $meta_value) {
+        $the_post = wp_is_post_revision( $post_id );
+        if ( $the_post ) {
+            $post_id = $the_post;
+        }
+    
+        return add_post_meta( 'post', $post_id, $meta_key, $meta_value);
+    }
+
+    add_action( 'init', 'register_news_cpt' );
+    function register_news_cpt() {
+        register_post_type( 'news',array(
+                                    'labels' => 
+                                        array(
+                                            'name' => __( 'News' ),
+                                            'singular_name' => __( 'News' ),
+                                            'description' => __('Independent sources'),
+                                        ),
+                                        'public' => true,
+                                        'has_archive' => false,
+                                        'rewrite' => array('slug' => 'news'),
+                                    )
+                            );
+        }
 ?>

--- a/wordpress/wp-content/themes/ws-custom-theme/index.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/index.php
@@ -1,1 +1,6 @@
 <h1>hello world!</h1>
+<?php
+    get_header();
+    the_content();
+    get_footer();
+?>


### PR DESCRIPTION
In template I called filter()
So it is corrected in the functions.php file
and Instead of add_metadata(), I used add_post_meta because, it add several meta values with same key.
As I called get_header(), it automatically includes the wp_head().So I removed wp_head().
![Screenshot (35)](https://github.com/DaraniShri/wordpress/assets/137259204/0eb78684-4bda-4d72-9827-1619f6e626da)
