### PR TITLE
adjust(wordpress):custom post type created with plugin

### DIFF
--- a/wordpress/wp-content/themes/ws-custom-theme/archive-festivals.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/archive-festivals.php
@@ -1,0 +1,21 @@
+<div class="wrapper">
+    <div class="site-header" style="background-color:aqua">
+        <?php 
+        get_header(); ?>
+    </div>
+    <div class="container" style="background-color:white">
+        <?php
+            if ( have_posts() ) :
+                while( have_posts() ) : the_post() ;
+                    "<h2>".the_title()."</h2>";
+                    echo the_content();
+                    echo "<br>";
+                endwhile;
+            endif;        
+        ?>
+    </div>
+    <div class="site-footer" style="background-color:aqua">
+    <?php 
+    get_footer(); ?>
+    </div>
+</div>

--- a/wordpress/wp-content/themes/ws-custom-theme/archive-news.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/archive-news.php
@@ -1,0 +1,14 @@
+<?php 
+get_header(); ?>
+<div class="container">
+    <?php
+        if ( have_posts() ) :
+            while( have_posts() ) : the_post() ;
+                echo the_title();
+                echo the_content();
+                echo "<br>";
+            endwhile;
+        endif;        
+    ?>
+</div>
+<?php get_footer(); ?>

--- a/wordpress/wp-content/themes/ws-custom-theme/functions.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/functions.php
@@ -1,10 +1,38 @@
 <?php
-    function hook_javascript() {
-        ?>
-            <script>
-                alert('Hello world...');
-            </script>
-        <?php
-    }
     add_action('wp_head', 'hook_javascript');
+
+    function hook_javascript() {
+        echo "Hello world...<br>";
+        echo "This is an action hook";
+    }
+
+    $addMetaValues=apply_filters('writeMeta',1,'meta_description','post meta value');
+
+    add_filter('writeMeta','storeMetaPost',10,3);
+
+    function storeMetaPost( $post_id, $meta_key, $meta_value) {
+        $the_post = wp_is_post_revision( $post_id );
+        if ( $the_post ) {
+            $post_id = $the_post;
+        }
+    
+        return add_post_meta( 'post', $post_id, $meta_key, $meta_value);
+    }
+
+    add_action( 'init', 'register_news_cpt' );
+    function register_news_cpt() {
+        register_post_type( 'news',array(
+                                    'labels' => 
+                                        array(
+                                            'name' => __( 'News' ),
+                                            'singular_name' => __( 'News' ),
+                                            'description' => __('Independent sources'),
+                                        ),
+                                        "description" => "All the news content will be posted with this type of post",
+                                        'public' => true,
+                                        'has_archive' => true,
+                                        'rewrite' => array('slug' => 'news'),
+                                    )
+                            );
+        }
 ?>

--- a/wordpress/wp-content/themes/ws-custom-theme/index.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/index.php
@@ -1,1 +1,4 @@
-<h1>hello world!</h1>
+<?php
+    get_header();
+    get_footer();
+?>

--- a/wordpress/wp-content/themes/ws-custom-theme/single-festivals.php
+++ b/wordpress/wp-content/themes/ws-custom-theme/single-festivals.php
@@ -1,0 +1,10 @@
+<div id="main-content" class="main-content">
+    <div id="primary" class="content-area">
+        <div id="content" class="site-content" role="main">
+            <?php
+                echo the_title();
+                echo the_content();
+            ?>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
A custom post type is created  with the help of **CUSTOM POST TYPE UI** plugin
![Screenshot (38)](https://github.com/DaraniShri/wordpress/assets/137259204/f6f54dc7-1ef0-4928-8316-599cc3f274d3)
A custom post type with the name **FESTIVALS** is created
![Screenshot (36)](https://github.com/DaraniShri/wordpress/assets/137259204/313ac18a-ebc0-4c62-ac71-e16481a9d813)
And I have created **TAXONOMY** in the name of _religions_
![Screenshot (42)](https://github.com/DaraniShri/wordpress/assets/137259204/7ff89391-2de9-4b97-872a-bd1e8ac418a1)
single page and archive page is created for **Festivals**
![Screenshot (40)](https://github.com/DaraniShri/wordpress/assets/137259204/354b55f5-960b-495b-b903-59b191c61f02)
![Screenshot (41)](https://github.com/DaraniShri/wordpress/assets/137259204/08e48abc-33ec-45dd-916c-8c2de19ee54f)
**Note:** Styles (In progress)
